### PR TITLE
Extrawurst for Blitz/Feed-Me brought back to V1 of Relax (=Craft 3 Ve…

### DIFF
--- a/src/Handlers/QueueServiceHandler.php
+++ b/src/Handlers/QueueServiceHandler.php
@@ -43,5 +43,19 @@ class QueueServiceHandler
         if (isset(Craft::$app->controllerMap['queue']['queue'])) {
             Craft::$app->controllerMap['queue']['queue'] = $queue;
         }
+
+        // Extrawurst for feed-me
+        if ($feedMe = Craft::$app->getPlugins()->getPlugin('feed-me')) {
+            if (property_exists($feedMe, 'queue')) {
+                $feedMe->queue = $queue;
+            }
+        };
+
+        // Extrawurst for blitz
+        if ($blitz = Craft::$app->getPlugins()->getPlugin('blitz')) {
+            if (property_exists($blitz, 'queue')) {
+                $blitz->queue = $queue;
+            }
+        };
     }
 }


### PR DESCRIPTION
Hi Oliver,
I brought your Blitz Extrawurst (and also Feed-Me) back to your 1.0.x version.
In my setup it repairs Blitz 3 functionality with Relax 1 in Craft 3. 
I guess you could make it your 1.0.2.

This request referes to this issue (https://github.com/ostark/craft-relax/issues/16) for Craft 3.

schöne Grüße,
Matthias
